### PR TITLE
fix: stop exposing raw API keys in GET /api/config response

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -32,6 +32,25 @@ reviews:
     base_branches:
       - main
       - master
+  ignore_patterns:
+    - "**/*.md"
+    - "data/**/*"
+    - "models/**/*"
+    - "**/*.pkl"
+    - "**/*.faiss"
+    - "**/*.db"
+    - "**/*.log"
+    - "**/node_modules/**"
+    - "**/__pycache__/**"
+    - "**/venv*/**"
+    - "**/.pytest_cache/**"
+    - "**/*.pyc"
+    - "package-lock.json"
+    - "npm-debug.log"
+    - ".gitignore"
+    - "*.png"
+    - "*.jpg"
+    - "*.jpeg"
 
 # Path-specific instructions for reviewers
 path_instructions:
@@ -176,28 +195,6 @@ path_instructions:
     instructions: |
       Vitest Not Jest:
       Verify all test imports use 'vitest' package, not 'jest'. Check for vi.fn() instead of jest.fn()
-
-# File patterns to ignore in reviews
-reviews:
-  ignore_patterns:
-    - "**/*.md"  # Documentation will still be reviewed but with lower priority
-    - "data/**/*"  # Generated data files
-    - "models/**/*"  # Downloaded model binaries
-    - "**/*.pkl"  # Pickle files
-    - "**/*.faiss"  # FAISS index files
-    - "**/*.db"  # SQLite databases
-    - "**/*.log"  # Log files
-    - "**/node_modules/**"  # Node dependencies
-    - "**/__pycache__/**"  # Python cache
-    - "**/venv*/**"  # Virtual environments
-    - "**/.pytest_cache/**"  # Test cache
-    - "**/*.pyc"  # Python bytecode
-    - "package-lock.json"  # Lock files
-    - "npm-debug.log"  # Debug logs
-    - ".gitignore"  # Git config
-    - "*.png"  # Images
-    - "*.jpg"  # Images
-    - "*.jpeg"  # Images
 
 # Chat settings
 chat:

--- a/backend/api.py
+++ b/backend/api.py
@@ -767,10 +767,10 @@ async def get_config(request: Request):
     return {
         "folders": folders,
         "auto_index": config.getboolean('General', 'auto_index', fallback=False),
-        "openai_api_key": config.get('APIKeys', 'openai_api_key', fallback=''),
-        "gemini_api_key": config.get('APIKeys', 'gemini_api_key', fallback=''),
-        "anthropic_api_key": config.get('APIKeys', 'anthropic_api_key', fallback=''),
-        "grok_api_key": config.get('APIKeys', 'grok_api_key', fallback=''),
+        "openai_api_key_set": bool(config.get('APIKeys', 'openai_api_key', fallback='')),
+        "gemini_api_key_set": bool(config.get('APIKeys', 'gemini_api_key', fallback='')),
+        "anthropic_api_key_set": bool(config.get('APIKeys', 'anthropic_api_key', fallback='')),
+        "grok_api_key_set": bool(config.get('APIKeys', 'grok_api_key', fallback='')),
         "local_model_path": config.get('LocalLLM', 'model_path', fallback=''),
         "provider": config.get('LocalLLM', 'provider', fallback='openai'),
         "tensor_split": config.get('LocalLLM', 'tensor_split', fallback=None),
@@ -791,16 +791,22 @@ async def update_config(config_data: ConfigModel, request: Request):
     Returns:
         dict: Success status and message.
     """
+    existing = load_config()
     config = configparser.ConfigParser()
     config['General'] = {
         'folders': ','.join(config_data.folders),
         'auto_index': str(config_data.auto_index)
     }
+    # Preserve existing key if client submits empty string (i.e. user left it blank)
+    def _key(new_val, section, option):
+        if new_val:
+            return new_val
+        return existing.get(section, option, fallback='')
     config['APIKeys'] = {
-        'openai_api_key': config_data.openai_api_key or '',
-        'gemini_api_key': config_data.gemini_api_key or '',
-        'anthropic_api_key': config_data.anthropic_api_key or '',
-        'grok_api_key': config_data.grok_api_key or ''
+        'openai_api_key': _key(config_data.openai_api_key, 'APIKeys', 'openai_api_key'),
+        'gemini_api_key': _key(config_data.gemini_api_key, 'APIKeys', 'gemini_api_key'),
+        'anthropic_api_key': _key(config_data.anthropic_api_key, 'APIKeys', 'anthropic_api_key'),
+        'grok_api_key': _key(config_data.grok_api_key, 'APIKeys', 'grok_api_key'),
     }
     config['LocalLLM'] = {
         'model_path': config_data.local_model_path or '', 

--- a/backend/api.py
+++ b/backend/api.py
@@ -791,8 +791,7 @@ async def update_config(config_data: ConfigModel, request: Request):
     Returns:
         dict: Success status and message.
     """
-    existing = load_config()
-    config = configparser.ConfigParser()
+    config = load_config()
     config['General'] = {
         'folders': ','.join(config_data.folders),
         'auto_index': str(config_data.auto_index)
@@ -801,7 +800,7 @@ async def update_config(config_data: ConfigModel, request: Request):
     def _key(new_val, section, option):
         if new_val:
             return new_val
-        return existing.get(section, option, fallback='')
+        return config.get(section, option, fallback='')
     config['APIKeys'] = {
         'openai_api_key': _key(config_data.openai_api_key, 'APIKeys', 'openai_api_key'),
         'gemini_api_key': _key(config_data.gemini_api_key, 'APIKeys', 'gemini_api_key'),

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -93,8 +93,7 @@ function App() {
         try {
             const currentConfig = await axios.get('http://localhost:8000/api/config');
             await axios.post('http://localhost:8000/api/config', {
-                folders: currentConfig.data.folders || [],
-                auto_index: currentConfig.data.auto_index,
+                ...currentConfig.data,
                 provider: 'local',
                 local_model_path: modelPath
             });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -95,7 +95,6 @@ function App() {
             await axios.post('http://localhost:8000/api/config', {
                 folders: currentConfig.data.folders || [],
                 auto_index: currentConfig.data.auto_index,
-                openai_api_key: currentConfig.data.openai_api_key,
                 provider: 'local',
                 local_model_path: modelPath
             });

--- a/frontend/src/components/SettingsModal.jsx
+++ b/frontend/src/components/SettingsModal.jsx
@@ -118,7 +118,19 @@ const SettingsModal = ({ isOpen, onClose, onSave, activeModel }) => {
     const fetchConfig = async () => {
         try {
             const response = await axios.get(`${API}/api/config`);
-            setConfig(prev => ({ ...prev, ...response.data }));
+            const data = response.data;
+            // Backend returns _set booleans, not actual keys — keep form fields empty
+            const normalized = { ...data };
+            ['openai', 'gemini', 'anthropic', 'grok'].forEach(p => {
+                normalized[`${p}_api_key`] = '';
+                delete normalized[`${p}_api_key_set`];
+            });
+            setConfig(prev => ({ ...prev, ...normalized, _apiKeySet: {
+                openai: data.openai_api_key_set,
+                gemini: data.gemini_api_key_set,
+                anthropic: data.anthropic_api_key_set,
+                grok: data.grok_api_key_set,
+            }}));
         } catch (error) {
             console.error('Failed to fetch config:', error);
         }
@@ -618,7 +630,7 @@ const SettingsModal = ({ isOpen, onClose, onSave, activeModel }) => {
                                             value={config[provider.key] || ''}
                                             onChange={(e) => setConfig({ ...config, [provider.key]: e.target.value })}
                                             className="w-full px-3 py-2 text-sm rounded-lg border border-input bg-background"
-                                            placeholder={provider.placeholder}
+                                            placeholder={config._apiKeySet?.[provider.id] ? '••••••••  (key set — enter new value to replace)' : provider.placeholder}
                                         />
                                     </div>
                                 ))}

--- a/frontend/src/test/SettingsModal.test.jsx
+++ b/frontend/src/test/SettingsModal.test.jsx
@@ -23,10 +23,10 @@ const mockConfig = {
     folders: ['C:/Users/test/Documents'],
     auto_index: false,
     provider: 'local',
-    openai_api_key: '',
-    gemini_api_key: '',
-    anthropic_api_key: '',
-    grok_api_key: '',
+    openai_api_key_set: false,
+    gemini_api_key_set: false,
+    anthropic_api_key_set: false,
+    grok_api_key_set: false,
     local_model_path: '',
     local_model_type: 'llamacpp'
 }


### PR DESCRIPTION
## Summary

Fixes #54 — API keys were returned in plaintext from `GET /api/config`, exposing them in browser history, network logs, and proxy caches.

- **Backend:** `GET /api/config` now returns `openai_api_key_set`, `gemini_api_key_set`, `anthropic_api_key_set`, `grok_api_key_set` (booleans) instead of raw key strings
- **Backend:** `POST /api/config` preserves existing stored keys when the client submits an empty string (so saving other settings doesn't blank configured keys)
- **Frontend:** `SettingsModal` reads the `_set` booleans and shows a `"(key set — enter new value to replace)"` placeholder when a key is already configured; form fields remain empty on load
- **Frontend:** `App.jsx` model-switch no longer reads `openai_api_key` from the config response (would have passed a boolean as the key)
- **Tests:** Mock config updated to use the new `_set` field names

## Reviewer notes

- Users who previously had keys displayed pre-filled in the settings form will now see an empty input with a placeholder — this is intentional and more secure
- Submitting the form with an empty key field preserves the existing stored key; to clear a key, the user would need a separate "clear key" action (out of scope for this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)