### PR TITLE
fix(api): add pagination to /api/files endpoint

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1395,22 +1395,29 @@ async def open_file(request: dict, req: Request, _=Depends(verify_local_request)
         raise HTTPException(status_code=500, detail=f"Failed to open file: {str(e)}")
 
 @app.get("/api/files")
-async def list_indexed_files(request: Request):
+async def list_indexed_files(request: Request, limit: int = 100, offset: int = 0):
     """
-    List all documents currently in the database.
+    List indexed documents with pagination.
 
     Args:
         request (Request): The incoming request.
+        limit (int): Maximum number of files to return (default 100, capped at 500).
+        offset (int): Number of files to skip for pagination (default 0).
 
     Returns:
-        List[dict]: Metadata for all indexed files.
+        dict: {"files": [...], "total": int, "limit": int, "offset": int}
 
     Raises:
-        HTTPException: 500 if database retrieval fails.
+        HTTPException: 400 for invalid pagination params, 500 if database retrieval fails.
     """
+    if limit < 1 or limit > 500:
+        raise HTTPException(status_code=400, detail="limit must be between 1 and 500")
+    if offset < 0:
+        raise HTTPException(status_code=400, detail="offset must be non-negative")
     try:
-        files = await asyncio.to_thread(database.get_all_files)
-        return files
+        files = await asyncio.to_thread(database.get_all_files, limit, offset)
+        total = await asyncio.to_thread(database.count_files)
+        return {"files": files, "total": total, "limit": limit, "offset": offset}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -241,19 +241,38 @@ def add_files_batch(files_data: List[Dict]):
     finally:
         conn.close()
 
-def get_all_files() -> List[Dict]:
+def get_all_files(limit: int = 100, offset: int = 0) -> List[Dict]:
     """
-    Retrieve all indexed files from the database.
+    Retrieve indexed files from the database with pagination.
+
+    Args:
+        limit (int): Maximum number of rows to return. Defaults to 100.
+        offset (int): Number of rows to skip. Defaults to 0.
 
     Returns:
         List[Dict]: A list of rows representing indexed files.
     """
     conn = get_connection()
     cursor = conn.cursor()
-    cursor.execute('SELECT * FROM files ORDER BY filename')
+    cursor.execute('SELECT * FROM files ORDER BY filename LIMIT ? OFFSET ?', (limit, offset))
     files = [dict(row) for row in cursor.fetchall()]
     conn.close()
     return files
+
+
+def count_files() -> int:
+    """
+    Return the total number of indexed files in the database.
+
+    Returns:
+        int: Total file count.
+    """
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute('SELECT COUNT(*) FROM files')
+    count = cursor.fetchone()[0]
+    conn.close()
+    return count
 
 def get_file_by_path(path: str) -> Optional[Dict]:
     """

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -290,18 +290,24 @@ class TestAPIFileOperations(unittest.TestCase):
     def tearDown(self):
         app.dependency_overrides = {}
 
+    @patch('backend.database.count_files')
     @patch('backend.database.get_all_files')
-    def test_list_indexed_files(self, mock_get_files):
-        """Test listing indexed files."""
+    def test_list_indexed_files(self, mock_get_files, mock_count_files):
+        """Test listing indexed files returns paginated response."""
         mock_get_files.return_value = [
             {'id': 1, 'filename': 'test.pdf', 'path': '/test.pdf', 'size_bytes': 1024}
         ]
-        
+        mock_count_files.return_value = 1
+
         response = self.client.get("/api/files")
-        
+
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertIsInstance(data, list)
+        self.assertIsInstance(data, dict)
+        self.assertIn('files', data)
+        self.assertIn('total', data)
+        self.assertEqual(data['total'], 1)
+        self.assertEqual(len(data['files']), 1)
 
     def test_validate_path_valid(self):
         """Test validating a valid path."""


### PR DESCRIPTION
## Summary

Fixes [Bug #61](https://github.com/BhurkeSiddhesh/Docu-AI-Search/issues/61) — the `GET /api/files` endpoint previously returned every indexed file in a single unbounded response, which could produce multi-MB payloads and freeze the frontend for large document collections.

- `database.get_all_files()` now accepts `limit` and `offset` parameters using SQL `LIMIT`/`OFFSET`
- Added `database.count_files()` to return the total number of indexed files
- `GET /api/files` accepts `?limit=` and `?offset=` query params (default `limit=100`, capped at 500)
- Response shape changed from a bare list to `{"files": [...], "total": N, "limit": N, "offset": N}`
- Updated `test_api.py` to patch `count_files` and assert the new paginated dict shape

## Test plan

- [x] `backend/tests/test_database.py` — all 48 tests pass including `test_get_files_with_limit_and_offset`
- [x] `backend/tests/test_api.py::TestAPIFileOperations::test_list_indexed_files` updated to match new response shape (import error in that file is a pre-existing FastAPI version mismatch unrelated to this change)
- [ ] Manually verify `GET /api/files?limit=10&offset=0` returns first 10 files + total count
- [ ] Verify `GET /api/files?limit=600` returns HTTP 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)