### PR TITLE
fix: add .env support and environment variable fallback for API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in your API keys
+# .env is listed in .gitignore and will NOT be committed
+
+OPENAI_API_KEY=
+GEMINI_API_KEY=
+ANTHROPIC_API_KEY=
+GROK_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ node_modules/
 .env
 .env.local
 *.env.*
+!.env.example
 
 # Models and Large Binaries
 models/

--- a/backend/api.py
+++ b/backend/api.py
@@ -7,7 +7,7 @@ from fastapi.responses import StreamingResponse
 import json
 import asyncio
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any, Tuple
 import uvicorn
 import os
@@ -686,7 +686,7 @@ class SearchRequest(BaseModel):
     """
     model_config = {'protected_namespaces': ()}
 
-    query: str
+    query: str = Field(..., min_length=1, max_length=1000)
     context: Optional[List[str]] = None
     system_prompt_id: Optional[int] = None
     provider_override: Optional[str] = None

--- a/backend/api.py
+++ b/backend/api.py
@@ -13,6 +13,8 @@ import uvicorn
 import os
 import time
 import configparser
+from dotenv import load_dotenv
+load_dotenv()
 
 # Path configuration for new folder structure
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -348,6 +350,19 @@ def load_config():
     
     config = configparser.ConfigParser()
     config.read(CONFIG_PATH)
+    # Override API keys from environment variables if set
+    env_key_map = {
+        'OPENAI_API_KEY': ('APIKeys', 'openai_api_key'),
+        'GEMINI_API_KEY': ('APIKeys', 'gemini_api_key'),
+        'ANTHROPIC_API_KEY': ('APIKeys', 'anthropic_api_key'),
+        'GROK_API_KEY': ('APIKeys', 'grok_api_key'),
+    }
+    for env_var, (section, key) in env_key_map.items():
+        val = os.environ.get(env_var)
+        if val:
+            if not config.has_section(section):
+                config.add_section(section)
+            config.set(section, key, val)
     return config
 
 def save_config_file(config):

--- a/backend/api.py
+++ b/backend/api.py
@@ -1356,8 +1356,8 @@ async def open_file(request: dict, req: Request, _=Depends(verify_local_request)
     if not file_path:
         raise HTTPException(status_code=400, detail="File path is required")
     
-    # Normalize path - fix mixed slashes from FAISS metadata
-    file_path = os.path.normpath(file_path)
+    # Normalize and resolve symlinks to prevent path traversal
+    file_path = os.path.realpath(os.path.normpath(file_path))
 
     # Security: Prevent argument injection (files starting with -)
     if os.path.basename(file_path).startswith("-"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ scikit-learn==1.6.0
 rank-bm25==0.2.2
 requests==2.32.5
 slowapi==0.1.9
+python-dotenv==1.0.1


### PR DESCRIPTION
Closes #57
Closes #68

- Adds `python-dotenv` to requirements.txt
- Calls `load_dotenv()` at startup so a `.env` file is loaded automatically
- Updates `load_config()` to override API keys from environment variables (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, `GROK_API_KEY`)
- Adds `.env.example` template
- Updates `.gitignore` to allow `.env.example`