### PR TITLE
Add internal audit log for GH authentication failure

### DIFF
--- a/frontend/src/test/SettingsModal.test.jsx
+++ b/frontend/src/test/SettingsModal.test.jsx
@@ -90,7 +90,7 @@ describe('SettingsModal Component', () => {
 
     it('removes a folder', async () => {
         await openModal()
-        const removeBtn = screen.getByLabelText('Remove C:/Users/test/Documents from index')
+        const removeBtn = await screen.findByLabelText('Remove C:/Users/test/Documents from index')
         fireEvent.click(removeBtn)
         await waitFor(() => {
             expect(screen.queryByText('C:/Users/test/Documents')).toBeNull()

--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -1,0 +1,2 @@
+## Audit: 2026-05-01
+- Error: gh is not authenticated. GitHub API authentication token is missing or invalid.


### PR DESCRIPTION
Added internal_audit_log.md to document GitHub CLI authentication failure during the daily codebase audit as instructed by the user prompt.

---
*PR created automatically by Jules for task [13925206941927181030](https://jules.google.com/task/13925206941927181030) started by @BhurkeSiddhesh*