### PR TITLE
Log GitHub CLI auth failure during automated audit

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -1,0 +1,4 @@
+## Audit: 2026-05-09
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)


### PR DESCRIPTION
The execution environment does not have the GitHub CLI (`gh`) authenticated, which is required to fetch existing issues and file new ones. Per the instructions, this is treated as an authentication failure and logged appropriately to `internal_audit_log.md` with zero issues filed.

---
*PR created automatically by Jules for task [1135667983593194874](https://jules.google.com/task/1135667983593194874) started by @BhurkeSiddhesh*