### PR TITLE
Add internal audit log for gh authentication failure

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -1,0 +1,4 @@
+## Audit: 2026-05-14
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)


### PR DESCRIPTION
Added an internal audit log file `internal_audit_log.md` detailing the failure to authenticate with the GitHub CLI (`gh`). No actual codebase modifications were performed.

---
*PR created automatically by Jules for task [14319542534076358160](https://jules.google.com/task/14319542534076358160) started by @BhurkeSiddhesh*