### PR TITLE
Add internal audit log for gh auth failure

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -1,0 +1,4 @@
+## Audit: 2026-05-16
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)


### PR DESCRIPTION
Created `internal_audit_log.md` with an entry noting an authentication failure for the GitHub CLI (`gh`). This complies with the negative path requirement to stop and log when unauthenticated, instead of attempting to fetch or file issues.

---
*PR created automatically by Jules for task [1768548477568907501](https://jules.google.com/task/1768548477568907501) started by @BhurkeSiddhesh*