### PR TITLE
chore: update internal audit log for GitHub CLI auth failure

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -1,0 +1,4 @@
+## Audit: 2026-05-18
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)


### PR DESCRIPTION
Updates the internal audit log to correctly handle the condition where the GitHub CLI (`gh`) tool fails authentication. A new `internal_audit_log.md` file was created with strict formatting containing 0 filed issues and an "Authentication failure for GitHub CLI (gh)" status message. This avoids automated processing crashes and fulfills operational requirements.

---
*PR created automatically by Jules for task [4602827893023519343](https://jules.google.com/task/4602827893023519343) started by @BhurkeSiddhesh*