### PR TITLE
Add internal audit log for GitHub CLI auth failure

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -1,0 +1,4 @@
+## Audit: 2026-05-23
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)


### PR DESCRIPTION
This submission adds the `internal_audit_log.md` file to the root directory. It contains a daily audit entry for 2026-05-23 noting an authentication failure for the GitHub CLI (`gh`), as requested by the daily automated code audit instructions when `gh` is unavailable. Tests and structure validations were also executed.

---
*PR created automatically by Jules for task [3771383023867463314](https://jules.google.com/task/3771383023867463314) started by @BhurkeSiddhesh*