### PR TITLE
chore: fix log 2026-05-30

### DIFF
--- a/internal_fix_log.md
+++ b/internal_fix_log.md
@@ -1,0 +1,11 @@
+# Internal Fix Log
+
+## Fix Pass: 2026-05-30
+
+Issue #235 — [Critical Bug] GET /api/config returns external_api_key in plaintext — PR opened — PR #248
+Issue #230 — [Critical Bug] Agentic /api/search passes raw dicts to StreamingResponse — PR opened — PR #249
+Issue #224 — [Critical Bug] POST/DELETE /api/system-prompts missing require_auth — PR opened — PR #250
+Issue #212 — [Critical Bug] Data-access endpoints missing require_auth — PR opened — PR #251
+Issue #211 — [Critical Bug] Missing .dockerignore — PR opened — PR #252
+
+Summary: 5 PRs opened · 0 escalated · 0 auto-closed · 5 skipped (already have PR: #237, #229, #228, #221, #129)


### PR DESCRIPTION
Adds `internal_fix_log.md` recording the daily fix pass for 2026-05-30.

5 Critical Bug PRs opened: #248 #249 #250 #251 #252

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVLW7ztp8NS6pGmtug5vma)_