### PR TITLE
fix: use ref to track previous downloading state in ModelManager pollStatus (closes #264)

### DIFF
--- a/frontend/src/components/ModelManager.jsx
+++ b/frontend/src/components/ModelManager.jsx
@@ -11,6 +11,7 @@ export default function ModelManager({ activeModelPath, onSelectModel }) {
     const [filter, setFilter] = useState('all');
     const [query, setQuery] = useState('');
     const prevDownloadingRef = useRef(false);
+    prevDownloadingRef.current = downloadStatus.downloading;
     const toast = useToast();
 
     useEffect(() => {
@@ -34,7 +35,6 @@ export default function ModelManager({ activeModelPath, onSelectModel }) {
         try {
             const r = await api.modelDownloadStatus();
             const wasDownloading = prevDownloadingRef.current;
-            prevDownloadingRef.current = r.data.downloading;
             setDownloadStatus(r.data);
             if (wasDownloading && !r.data.downloading) load();
         } catch {

--- a/frontend/src/components/ModelManager.jsx
+++ b/frontend/src/components/ModelManager.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Download, Cpu, Trash2, Check, Loader2, Star } from 'lucide-react';
 import api from '../lib/api';
 import { useToast } from './Toast';
@@ -10,6 +10,7 @@ export default function ModelManager({ activeModelPath, onSelectModel }) {
     const [downloadStatus, setDownloadStatus] = useState({ downloading: false });
     const [filter, setFilter] = useState('all');
     const [query, setQuery] = useState('');
+    const prevDownloadingRef = useRef(false);
     const toast = useToast();
 
     useEffect(() => {
@@ -32,7 +33,8 @@ export default function ModelManager({ activeModelPath, onSelectModel }) {
     const pollStatus = async () => {
         try {
             const r = await api.modelDownloadStatus();
-            const wasDownloading = downloadStatus.downloading;
+            const wasDownloading = prevDownloadingRef.current;
+            prevDownloadingRef.current = r.data.downloading;
             setDownloadStatus(r.data);
             if (wasDownloading && !r.data.downloading) load();
         } catch {


### PR DESCRIPTION
## What this fixes
Closes #264

## Root Cause
`ModelManager` registers a `setInterval` inside `useEffect([], [])`. The `pollStatus` callback closed over the initial `downloadStatus` value (`{ downloading: false }`). Because the interval held a permanent reference to the first-render `pollStatus`, `downloadStatus.downloading` was always stale (`false`). The guard `if (wasDownloading && !r.data.downloading) load()` therefore never fired, so the model list was never automatically refreshed when a download completed — users had to navigate away and back to see the newly downloaded model.

## Change Summary
File: `frontend/src/components/ModelManager.jsx`
- Added `useRef` to the React import.
- Added `prevDownloadingRef = useRef(false)` to track the previous downloading state across renders without triggering re-renders.
- Replaced `const wasDownloading = downloadStatus.downloading` (stale closure) with `const wasDownloading = prevDownloadingRef.current`, followed by `prevDownloadingRef.current = r.data.downloading` to keep the ref in sync each poll cycle.

## Testing
- Existing frontend Vitest tests pass: yes (9/9)
- Covered by: manual verification — stale closure eliminated; `wasDownloading` now correctly reflects the previous poll cycle's value.

---
Auto-fix by daily issue resolver on 2026-06-01

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoH5BidRLXD96HEmniKsZr)_