### PR TITLE
fix: add verify_local_request to POST /api/config (closes #170)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -896,7 +896,7 @@ async def get_config(request: Request):
 
 @app.post("/api/config")
 @limiter.limit("10/minute")
-async def update_config(config_data: ConfigModel, request: Request):
+async def update_config(config_data: ConfigModel, request: Request, _=Depends(verify_local_request)):
     """
     Update the application configuration.
 


### PR DESCRIPTION
## What this fixes
Closes #170

## Root Cause
`POST /api/config` writes all four LLM provider API keys plus the indexed folder path to `config.ini`, but had no `verify_local_request` guard. Because CORS was `allow_origins=["*"]`, any remote host that could reach port 8000 could silently replace or clear the user's API keys — enabling billing hijack, query exfiltration, or denial-of-service. Contrast with `/api/auth/token`, `/api/open-file`, and `/api/browse`, which all already used `Depends(verify_local_request)`.

## Change Summary
File: `backend/api.py` (line 899)
- Added `_=Depends(verify_local_request)` as a FastAPI dependency parameter to `update_config()`, identical to the pattern already used on sensitive endpoints in the same file.

## Testing
- Backend quick tests pass for all non-import-error tests (pre-existing fastapi import failures in env, unrelated to this change)
- Covered by: pattern is identical to existing `verify_local_request` usage on other endpoints; one-line additive change with no logic impact.

---
Auto-fix by daily issue resolver on 2026-06-01

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoH5BidRLXD96HEmniKsZr)_