### PR TITLE
fix: pass api_key to get_embeddings in tool_search_knowledge_base

### DIFF
--- a/backend/tools.py
+++ b/backend/tools.py
@@ -21,12 +21,21 @@ def tool_search_knowledge_base(query: str, global_state: dict) -> str:
     if not global_state.get('index'):
         return "Error: No knowledge base indexed."
         
+    provider = global_state['config'].get('LocalLLM', 'provider', fallback='openai')
+    _key_map = {
+        'openai': ('APIKeys', 'openai_api_key'),
+        'gemini': ('APIKeys', 'gemini_api_key'),
+        'anthropic': ('APIKeys', 'anthropic_api_key'),
+        'grok': ('APIKeys', 'grok_api_key'),
+    }
+    _section, _key = _key_map.get(provider, ('APIKeys', 'openai_api_key'))
+    api_key = global_state['config'].get(_section, _key, fallback=None)
     results, _ = search.search(
-        query, 
-        global_state['index'], 
-        global_state['docs'], 
-        global_state['tags'], 
-        llm_integration.get_embeddings(global_state['config'].get('LocalLLM', 'provider', fallback='openai')),
+        query,
+        global_state['index'],
+        global_state['docs'],
+        global_state['tags'],
+        llm_integration.get_embeddings(provider, api_key),
         global_state.get('index_summaries'),
         global_state.get('cluster_summaries'),
         global_state.get('cluster_map'),

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -21,15 +21,18 @@ def tool_search_knowledge_base(query: str, global_state: dict) -> str:
     if not global_state.get('index'):
         return "Error: No knowledge base indexed."
         
-    provider = global_state['config'].get('LocalLLM', 'provider', fallback='openai')
+    config = global_state.get('config')
+    if not config:
+        return "Error: Configuration not found in global state."
+    provider = config.get('LocalLLM', 'provider', fallback='openai')
     _key_map = {
         'openai': ('APIKeys', 'openai_api_key'),
         'gemini': ('APIKeys', 'gemini_api_key'),
         'anthropic': ('APIKeys', 'anthropic_api_key'),
         'grok': ('APIKeys', 'grok_api_key'),
     }
-    _section, _key = _key_map.get(provider, ('APIKeys', 'openai_api_key'))
-    api_key = global_state['config'].get(_section, _key, fallback=None)
+    _section_key = _key_map.get(provider)
+    api_key = config.get(_section_key[0], _section_key[1], fallback=None) if _section_key else None
     results, _ = search.search(
         query,
         global_state['index'],


### PR DESCRIPTION
## What this fixes
Closes #139

## Root Cause
`tool_search_knowledge_base` in `backend/tools.py` called `llm_integration.get_embeddings(provider)` with only the provider name and no `api_key`. Inside `get_embeddings`, every cloud-provider branch (`openai`, `gemini`, `grok`) is guarded by `and api_key`, so `api_key=None` causes the function to fall through to the local HuggingFace `all-MiniLM-L6-v2` model (384-dim). When the FAISS index was built with a cloud provider (1536-dim OpenAI, 768-dim Gemini), this dimension mismatch raises `EmbeddingDimensionMismatchError` on every agentic search call.

## Change Summary
- `backend/tools.py`: resolve `provider` from `global_state['config']`, look up the corresponding `api_key` from the `APIKeys` section, and pass both to `get_embeddings`.

## Merge Disposition
awaits human review
Confidence: MEDIUM
Priority: P1

## Testing
- Existing tests pass: yes (CI)
- Covered by: no targeted test — the agent search path requires a live index; manual verification recommended

---
Auto-fix by daily issue resolver on 2026-06-01

---
_Generated by [Claude Code](https://claude.ai/code/session_01N19WZZXwgGXcjLu4bdojtF)_