### PR TITLE
fix: add verify_local_request and localhost URL validation to provider endpoints

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1284,11 +1284,13 @@ class ProviderQueryRequest(BaseModel):
     api_key: Optional[str] = ""
 
 def _validate_local_provider_url(base_url: Optional[str]) -> None:
-    """Reject non-localhost base_url values to prevent SSRF."""
+    """Reject non-localhost or non-HTTP(S) base_url values to prevent SSRF."""
     if not base_url:
         return
     from urllib.parse import urlparse
     parsed = urlparse(base_url)
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(status_code=400, detail="base_url must use http or https scheme")
     if parsed.hostname not in ("localhost", "127.0.0.1", "::1"):
         raise HTTPException(status_code=400, detail="base_url must point to localhost")
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -1283,9 +1283,19 @@ class ProviderQueryRequest(BaseModel):
     base_url: Optional[str] = None
     api_key: Optional[str] = ""
 
+def _validate_local_provider_url(base_url: Optional[str]) -> None:
+    """Reject non-localhost base_url values to prevent SSRF."""
+    if not base_url:
+        return
+    from urllib.parse import urlparse
+    parsed = urlparse(base_url)
+    if parsed.hostname not in ("localhost", "127.0.0.1", "::1"):
+        raise HTTPException(status_code=400, detail="base_url must point to localhost")
+
 @app.post("/api/providers/health")
-async def provider_health_check(body: ProviderQueryRequest, request: Request):
+async def provider_health_check(body: ProviderQueryRequest, request: Request, _=Depends(verify_local_request)):
     """Check if an external LLM provider (Ollama / LM Studio) is reachable."""
+    _validate_local_provider_url(body.base_url)
     from backend.providers import get_provider
     try:
         provider = get_provider(body.provider_type, {
@@ -1299,8 +1309,9 @@ async def provider_health_check(body: ProviderQueryRequest, request: Request):
         raise HTTPException(status_code=400, detail=str(e))
 
 @app.post("/api/providers/models")
-async def provider_list_models(body: ProviderQueryRequest, request: Request):
+async def provider_list_models(body: ProviderQueryRequest, request: Request, _=Depends(verify_local_request)):
     """Fetch available models from an external LLM provider."""
+    _validate_local_provider_url(body.base_url)
     from backend.providers import get_provider
     try:
         provider = get_provider(body.provider_type, {


### PR DESCRIPTION
## What this fixes
Closes #171

## Root Cause
`POST /api/providers/health` and `POST /api/providers/models` had no `verify_local_request` guard and accepted arbitrary `base_url` values. `OllamaProvider` and `OpenAICompatibleProvider` made outbound HTTP requests to whatever URL was supplied, enabling classic Server-Side Request Forgery (SSRF) — an attacker could supply `http://169.254.169.254/latest/meta-data/` or any internal host URL and the server would fetch and return the response.

## Change Summary
- `backend/api.py`: added `_=Depends(verify_local_request)` to both `provider_health_check` and `provider_list_models` endpoints to block non-localhost callers. Added `_validate_local_provider_url()` helper that rejects any `base_url` whose hostname is not `localhost`, `127.0.0.1`, or `::1`.

## Merge Disposition
awaits human review
Confidence: MEDIUM
Priority: P1

## Testing
- Existing tests pass: yes (CI)
- Covered by: no targeted test — verify_local_request behaviour is covered by existing auth tests; manual verification of SSRF rejection recommended

---
Auto-fix by daily issue resolver on 2026-06-01

---
_Generated by [Claude Code](https://claude.ai/code/session_01N19WZZXwgGXcjLu4bdojtF)_