### PR TITLE
fix: defer database.clear_files/clear_clusters to after indexing succeeds

### DIFF
--- a/backend/indexing.py
+++ b/backend/indexing.py
@@ -114,11 +114,7 @@ def create_index(folder_paths: List[str] | str, provider: str, api_key: str = No
     logger.info(f"Starting RAPTOR Indexing of folders: {folder_paths}")
     start_time = time.time()
     
-    # 1. Clear Database
-    database.clear_files()
-    database.clear_clusters()
-    
-    # 2. Collect Files
+    # 1. Collect Files (DB clear is deferred to after indexing succeeds)
     all_files = []
     for folder_path in folder_paths:
         if os.path.exists(folder_path):
@@ -198,11 +194,8 @@ def create_index(folder_paths: List[str] | str, provider: str, api_key: str = No
             'tags': '[]' # Default empty tags
         }
         
-        # Add to DB immediately
+        # Accumulate without writing — DB is updated atomically at the end
         files_to_add.append(file_info)
-        if len(files_to_add) >= 500:
-            database.add_files_batch(files_to_add)
-            files_to_add = []
         
         for chunk in chunks:
             all_chunks.append({
@@ -214,8 +207,6 @@ def create_index(folder_paths: List[str] | str, provider: str, api_key: str = No
             chunk_strings.append(chunk)
             current_faiss_idx += 1
             
-    if files_to_add:
-        database.add_files_batch(files_to_add)
     logger.info(f"Generated {len(chunk_strings)} total chunks.")
 
     if not chunk_strings:
@@ -346,9 +337,7 @@ def create_index(folder_paths: List[str] | str, provider: str, api_key: str = No
                 percent = 75 + int((processed_clusters / total_clusters) * 20)
                 progress_callback(percent, 100, f"Summarizing cluster {processed_clusters}/{total_clusters}")
 
-        # Batch insert clusters
-        if clusters_batch_data:
-            database.add_clusters_batch(clusters_batch_data)
+        # clusters_batch_data is written atomically after FAISS indices are built
     
     # 8. Create FAISS Indices - 95% to 99%
     if progress_callback: progress_callback(97, 100, "Finalizing Indices...")
@@ -383,6 +372,15 @@ def create_index(folder_paths: List[str] | str, provider: str, api_key: str = No
         'model_name': _model_name,
         'embedding_dim': _embedding_dim,
     }
+    # Atomically replace DB: clear old records only after all indexing work succeeded.
+    # This preserves the previous DB if the pipeline failed at any earlier stage.
+    database.clear_files()
+    database.clear_clusters()
+    if files_to_add:
+        database.add_files_batch(files_to_add)
+    if clusters_batch_data:
+        database.add_clusters_batch(clusters_batch_data)
+
     _clear_checkpoint()
     return index_chunks, all_chunks, tags, index_summaries, cluster_summaries, final_cluster_map, bm25, meta
 

--- a/backend/indexing.py
+++ b/backend/indexing.py
@@ -372,14 +372,34 @@ def create_index(folder_paths: List[str] | str, provider: str, api_key: str = No
         'model_name': _model_name,
         'embedding_dim': _embedding_dim,
     }
-    # Atomically replace DB: clear old records only after all indexing work succeeded.
-    # This preserves the previous DB if the pipeline failed at any earlier stage.
-    database.clear_files()
-    database.clear_clusters()
-    if files_to_add:
-        database.add_files_batch(files_to_add)
-    if clusters_batch_data:
-        database.add_clusters_batch(clusters_batch_data)
+    # Atomically replace DB inside a single transaction so a partial write
+    # (e.g. clear succeeds but insert fails) never leaves the DB empty.
+    conn = database.get_connection()
+    try:
+        conn.execute("BEGIN")
+        conn.execute("DELETE FROM files")
+        conn.execute("DELETE FROM clusters")
+        if files_to_add:
+            conn.executemany(
+                '''INSERT OR REPLACE INTO files
+                   (path, filename, file_type, size, last_modified,
+                    faiss_start_idx, faiss_end_idx, tags)
+                   VALUES (:path, :filename, :file_type, :size, :last_modified,
+                           :faiss_start_idx, :faiss_end_idx, :tags)''',
+                files_to_add,
+            )
+        if clusters_batch_data:
+            conn.executemany(
+                "INSERT INTO clusters (summary, level) VALUES (?, ?)",
+                clusters_batch_data,
+            )
+        conn.commit()
+    except Exception as exc:
+        conn.rollback()
+        logger.error("Failed to atomically update database after indexing: %s", exc)
+        raise
+    finally:
+        conn.close()
 
     _clear_checkpoint()
     return index_chunks, all_chunks, tags, index_summaries, cluster_summaries, final_cluster_map, bm25, meta


### PR DESCRIPTION
## What this fixes
Closes #165

## Root Cause
`create_index()` in `backend/indexing.py` called `database.clear_files()` and `database.clear_clusters()` at the very start of the function, before any indexing work. If the pipeline failed at any later stage (embedding API timeout, OOM during clustering, network drop, disk full), the SQLite metadata tables were left permanently empty. The FAISS index from the previous successful run might still exist on disk, so every search result would have a FAISS hit with no corresponding DB row.

## Change Summary
- `backend/indexing.py`: removed the upfront `clear_files()`/`clear_clusters()` calls and the incremental `add_files_batch` flushes during the chunking loop. File and cluster metadata is now accumulated in memory and written atomically (clear old → insert new) only after both FAISS indices are fully built — meaning a failed mid-pipeline run leaves the previous DB intact.

## Merge Disposition
awaits human review
Confidence: MEDIUM
Priority: P1

## Testing
- Existing tests pass: yes (CI)
- Covered by: existing indexing tests verify the DB is populated; failure-recovery path requires manual testing with an injected failure

---
Auto-fix by daily issue resolver on 2026-06-01

---
_Generated by [Claude Code](https://claude.ai/code/session_01N19WZZXwgGXcjLu4bdojtF)_