### PR TITLE
chore: update internal audit log with auth failure

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -371,3 +371,8 @@ Automated daily code audit results for [BhurkeSiddhesh/Docu-AI-Search](https://g
 
 ## Audit: 2026-05-01
 - Error: gh is not authenticated. GitHub API authentication token is missing or invalid.
+
+## Audit: 2026-06-05
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)


### PR DESCRIPTION
Appended a strict markdown log of the `gh` authentication failure to the `internal_audit_log.md` since `gh` command is not available in the environment.

---
*PR created automatically by Jules for task [5216563569366164205](https://jules.google.com/task/5216563569366164205) started by @BhurkeSiddhesh*