### PR TITLE
fix: wrap agent.stream_chat in SSE generator for /api/search agentic path (closes #125)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1016,7 +1016,16 @@ async def search_files(search_data: SearchRequest, request: Request, background_
                 'index_summaries': isumm_snap, 'cluster_summaries': csumm_snap,
                 'cluster_map': cmap_snap, 'bm25': bm25_snap
             })
-            return StreamingResponse(agent.stream_chat(search_data.query), media_type="text/event-stream")
+
+            async def _agentic_sse():
+                try:
+                    async for event in agent.stream_chat(search_data.query):
+                        yield f"data: {json.dumps(event)}\n\n"
+                except Exception as e:
+                    logger.error("[Agent/search] Stream error: %s", e)
+                    yield f"data: {json.dumps({'type': 'error', 'content': 'Agent error'})}\n\n"
+
+            return StreamingResponse(_agentic_sse(), media_type="text/event-stream")
 
         model_path = config.get('LocalLLM', 'model_path', fallback=None)
         tensor_split_str = config.get('LocalLLM', 'tensor_split', fallback=None)


### PR DESCRIPTION
## What this fixes
Closes #125

## Root Cause
`/api/search` in `backend/api.py` (line 1019) passed `agent.stream_chat()` directly to `StreamingResponse`. The generator yields Python `dict` objects; `StreamingResponse` calls `.encode()` on each yielded item, and `dict` has no `.encode()` method — raising `TypeError` and returning an empty stream on every agentic search request. The identical bug was previously fixed in `/api/agent/chat` (which wraps events with `f"data: {json.dumps(event)}\n\n"`), but that pattern was never applied to the `/api/search` agentic path.

## Change Summary
- `backend/api.py`: replaced the bare `StreamingResponse(agent.stream_chat(...))` with a local `async def _agentic_sse()` generator that serialises each event as `f"data: {json.dumps(event)}\n\n"` before yielding, with error handling matching the pattern in `/api/agent/chat`.

## Merge Disposition
awaits human review
Confidence: MEDIUM (no metadata block — manually filed issue)
Priority: P1

## Testing
- Existing tests pass: yes
- Covered by: no dedicated test for agentic search path — manual verification only; the fix is a direct port of the working `/api/agent/chat` pattern

---
Auto-fix by daily issue resolver on 2026-06-05

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzjhVnm5gcTsu74AcGdTkk)_