### PR TITLE
fix: add with_retry(stop_after_attempt=3) to LLM invoke/stream calls

### DIFF
--- a/backend/llm_integration.py
+++ b/backend/llm_integration.py
@@ -489,15 +489,15 @@ def generate_ai_answer(context: str, question: str, provider: str,
 
             messages.append(HumanMessage(content=user_content))
 
-            # Use bind for stop sequences if supported, otherwise just invoke
+            retry_client = client.with_retry(stop_after_attempt=3)
             if stop_seqs:
                  try:
-                    response = client.bind(stop=stop_seqs).invoke(messages)
+                    response = retry_client.bind(stop=stop_seqs).invoke(messages)
                  except Exception:
                     # Fallback if bind not supported
-                    response = client.invoke(messages)
+                    response = retry_client.invoke(messages)
             else:
-                 response = client.invoke(messages)
+                 response = retry_client.invoke(messages)
 
             return response.content.strip()
 
@@ -589,7 +589,8 @@ def stream_ai_answer(context: str, question: str, provider: str,
                 messages.append(SystemMessage(content=system_prompt))
             messages.append(HumanMessage(content=user_content))
 
-            for chunk in client.stream(messages):
+            retry_client = client.with_retry(stop_after_attempt=3)
+            for chunk in retry_client.stream(messages):
                  yield chunk.content
 
     except Exception as e:


### PR DESCRIPTION
## Summary

Fixes #316

`generate_ai_answer()` and `stream_ai_answer()` made single-shot `client.invoke()` / `client.stream()` calls with no retry logic. Transient HTTP 429 (rate-limit) or 5xx errors from the upstream LLM provider immediately surfaced as user-visible errors rather than being retried transparently.

## Change

Added `retry_client = client.with_retry(stop_after_attempt=3)` in the cloud (LangChain) path of both functions and replaced all `.bind().invoke()`, `.invoke()`, and `.stream()` calls with `retry_client`.

**`generate_ai_answer()` cloud path:**
```python
retry_client = client.with_retry(stop_after_attempt=3)
if stop_seqs:
    try:
        response = retry_client.bind(stop=stop_seqs).invoke(messages)
    except Exception:
        response = retry_client.invoke(messages)
else:
    response = retry_client.invoke(messages)
return response.content.strip()
```

**`stream_ai_answer()` cloud path:**
```python
retry_client = client.with_retry(stop_after_attempt=3)
for chunk in retry_client.stream(messages):
    yield chunk.content
```

## Test plan
- [ ] Mock LLM client to raise a 429 on the first two calls → verify third call succeeds and answer is returned
- [ ] Mock to always raise → verify error propagates after 3 attempts
- [ ] Stream path: mock first chunk raises 429 → verify retry delivers full stream

---

**Priority:** P2 MEDIUM  
**Merge Disposition:** awaits human review

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNDqndSAPgHAZ8KwcZygLt)_