### PR TITLE
chore: daily audit log 2026-06-07

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -371,3 +371,8 @@ Automated daily code audit results for [BhurkeSiddhesh/Docu-AI-Search](https://g
 
 ## Audit: 2026-05-01
 - Error: gh is not authenticated. GitHub API authentication token is missing or invalid.
+
+## Audit: 2026-06-07
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)


### PR DESCRIPTION
Appended the required authentication failure entry for the GitHub CLI (gh) to `internal_audit_log.md` since `gh` is not available in the execution environment, adhering to the project's explicit conditional constraint. Structure validation confirmed no regressions.

---
*PR created automatically by Jules for task [3608983411091975429](https://jules.google.com/task/3608983411091975429) started by @BhurkeSiddhesh*