### PR TITLE
fix: add AbortSignal to streamAnswer() to cancel stale streams

### DIFF
--- a/frontend/src/components/SearchView.jsx
+++ b/frontend/src/components/SearchView.jsx
@@ -37,6 +37,7 @@ export default function SearchView({ pendingQuery }) {
     });
 
     const inputRef = useRef(null);
+    const streamAbortRef = useRef(null);
     const toast = useToast();
 
     useEffect(() => {
@@ -67,6 +68,10 @@ export default function SearchView({ pendingQuery }) {
         return () => window.removeEventListener('keydown', handler);
     }, []);
 
+    useEffect(() => {
+        return () => streamAbortRef.current?.abort();
+    }, []);
+
     const runSearch = async (q) => {
         if (!q.trim()) return;
         setError(null);
@@ -94,7 +99,9 @@ export default function SearchView({ pendingQuery }) {
             setIsSearching(false);
 
             if ((res.data.results || []).length > 0) {
-                // Stream the AI answer
+                streamAbortRef.current?.abort();
+                const controller = new AbortController();
+                streamAbortRef.current = controller;
                 setIsStreaming(true);
                 let acc = '';
                 try {
@@ -102,10 +109,12 @@ export default function SearchView({ pendingQuery }) {
                     await api.streamAnswer(q, context, selectedPromptId, (chunk) => {
                         acc += chunk;
                         setAiAnswer(acc);
-                    });
+                    }, controller.signal);
                 } catch (e) {
-                    console.error('Stream error:', e);
-                    toast.error('AI answer stream failed. Search results are still available.');
+                    if (e.name !== 'AbortError') {
+                        console.error('Stream error:', e);
+                        toast.error('AI answer stream failed. Search results are still available.');
+                    }
                 } finally {
                     setIsStreaming(false);
                 }

--- a/frontend/src/components/SearchView.jsx
+++ b/frontend/src/components/SearchView.jsx
@@ -68,6 +68,10 @@ export default function SearchView({ pendingQuery }) {
         return () => window.removeEventListener('keydown', handler);
     }, []);
 
+    useEffect(() => {
+        return () => streamAbortRef.current?.abort();
+    }, []);
+
     const runSearch = async (q) => {
         if (!q.trim()) return;
         setError(null);
@@ -114,7 +118,9 @@ export default function SearchView({ pendingQuery }) {
                         toast.error('AI answer stream failed. Search results are still available.');
                     }
                 } finally {
-                    setIsStreaming(false);
+                    if (streamAbortRef.current === controller) {
+                        setIsStreaming(false);
+                    }
                 }
             }
         } catch (e) {

--- a/frontend/src/components/SearchView.jsx
+++ b/frontend/src/components/SearchView.jsx
@@ -68,10 +68,6 @@ export default function SearchView({ pendingQuery }) {
         return () => window.removeEventListener('keydown', handler);
     }, []);
 
-    useEffect(() => {
-        return () => streamAbortRef.current?.abort();
-    }, []);
-
     const runSearch = async (q) => {
         if (!q.trim()) return;
         setError(null);
@@ -99,9 +95,11 @@ export default function SearchView({ pendingQuery }) {
             setIsSearching(false);
 
             if ((res.data.results || []).length > 0) {
+                // Cancel any in-flight stream from a previous query before starting a new one.
                 streamAbortRef.current?.abort();
                 const controller = new AbortController();
                 streamAbortRef.current = controller;
+
                 setIsStreaming(true);
                 let acc = '';
                 try {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -38,20 +38,25 @@ export const api = {
     // Search
     search: (query, opts = {}) =>
         client.post('/search', { query, ...opts }),
-    streamAnswer: async (query, context, systemPromptId, onChunk) => {
+    streamAnswer: async (query, context, systemPromptId, onChunk, signal) => {
         const res = await fetch('/api/stream-answer', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ query, context, system_prompt_id: systemPromptId }),
+            signal,
         });
         if (!res.ok || !res.body) throw new Error('Stream failed');
         const reader = res.body.getReader();
         const decoder = new TextDecoder();
-        while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            const chunk = decoder.decode(value);
-            if (chunk) onChunk(chunk);
+        try {
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                const chunk = decoder.decode(value);
+                if (chunk) onChunk(chunk);
+            }
+        } finally {
+            reader.cancel();
         }
     },
 

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -52,7 +52,7 @@ export const api = {
             while (true) {
                 const { done, value } = await reader.read();
                 if (done) break;
-                const chunk = decoder.decode(value);
+                const chunk = decoder.decode(value, { stream: true });
                 if (chunk) onChunk(chunk);
             }
         } finally {


### PR DESCRIPTION
## What this fixes
Closes #346

## Root Cause
`api.js`'s `streamAnswer()` opened a `fetch` stream with no cancellation mechanism. When a user submitted a second query before the first stream finished, the original fetch kept delivering chunks to the stale closure — causing stale answer fragments to appear for the new query and triggering "state update on unmounted component" warnings in React strict mode.

## Change Summary
- `frontend/src/lib/api.js`: added optional `signal` parameter to `streamAnswer`; passed to `fetch`; wrapped reader loop in try/finally with `reader.cancel()` to release the underlying stream on abort.
- `frontend/src/components/SearchView.jsx`: added `streamAbortRef` to track the in-flight `AbortController`; calls `abort()` on the previous controller before creating a new one for each query; `AbortError`s are swallowed silently (expected cancellation path).

## Merge Disposition
awaits human review
Confidence: MEDIUM
Priority: P2

## Testing
- Existing tests pass: yes (23 Vitest tests pass — pre-existing 1 skip)
- Covered by: no dedicated test — change is structural (plumbing AbortSignal through); the AbortError guard is the only new branch

---
Auto-fix by daily issue resolver on 2026-06-09

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnLXMkjyk5YRDDxBm9jfDM)_