### PR TITLE
fix: add HTTP retry to OllamaProvider and OpenAICompatibleProvider

### DIFF
--- a/backend/providers.py
+++ b/backend/providers.py
@@ -27,8 +27,34 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Generator, List, Optional
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Retry helpers
+# ---------------------------------------------------------------------------
+
+def _make_retry_session(
+    retries: int = 3,
+    backoff_factor: float = 0.5,
+    status_forcelist: tuple = (502, 503, 504),
+) -> requests.Session:
+    """Return a requests.Session with automatic retry on transient errors."""
+    session = requests.Session()
+    retry = Retry(
+        total=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+        allowed_methods={"GET", "POST"},
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
 
 # ---------------------------------------------------------------------------
 # Abstract base
@@ -86,6 +112,7 @@ class OllamaProvider(LLMProvider):
         self.model = model
         self.api_key = api_key
         self._timeout = 120  # seconds
+        self._session = _make_retry_session()
 
     def _headers(self) -> dict:
         headers = {"Content-Type": "application/json"}
@@ -119,7 +146,7 @@ class OllamaProvider(LLMProvider):
             payload["options"]["stop"] = stop
 
         try:
-            resp = requests.post(
+            resp = self._session.post(
                 f"{self.base_url}/api/generate",
                 json=payload,
                 headers=self._headers(),
@@ -161,7 +188,7 @@ class OllamaProvider(LLMProvider):
             payload["options"]["stop"] = stop
 
         try:
-            resp = requests.post(
+            resp = self._session.post(
                 f"{self.base_url}/api/generate",
                 json=payload,
                 headers=self._headers(),
@@ -188,7 +215,7 @@ class OllamaProvider(LLMProvider):
 
     def list_models(self) -> List[Dict[str, Any]]:
         try:
-            resp = requests.get(
+            resp = self._session.get(
                 f"{self.base_url}/api/tags",
                 headers=self._headers(),
                 timeout=10,
@@ -218,7 +245,7 @@ class OllamaProvider(LLMProvider):
 
     def health_check(self) -> Dict[str, Any]:
         try:
-            resp = requests.get(f"{self.base_url}/api/tags", timeout=5)
+            resp = self._session.get(f"{self.base_url}/api/tags", timeout=5)
             resp.raise_for_status()
             model_count = len(resp.json().get("models", []))
             return {"status": "ok", "provider": "ollama", "models_available": model_count}
@@ -256,6 +283,7 @@ class OpenAICompatibleProvider(LLMProvider):
         self._timeout = 180  # Large models may need more time
         # Auto-detect API format: if URL ends with /v1, use OpenAI format
         self._use_openai_format = self.base_url.endswith("/v1")
+        self._session = _make_retry_session()
 
     def _headers(self) -> dict:
         return {
@@ -304,7 +332,7 @@ class OpenAICompatibleProvider(LLMProvider):
             payload["system_prompt"] = system_prompt
 
         try:
-            resp = requests.post(
+            resp = self._session.post(
                 f"{self.base_url}/api/v1/chat",
                 json=payload,
                 headers=self._headers(),
@@ -339,7 +367,7 @@ class OpenAICompatibleProvider(LLMProvider):
             payload["stop"] = stop
 
         try:
-            resp = requests.post(
+            resp = self._session.post(
                 f"{self.base_url}/chat/completions",
                 json=payload,
                 headers=self._headers(),
@@ -387,7 +415,7 @@ class OpenAICompatibleProvider(LLMProvider):
             payload["system_prompt"] = system_prompt
 
         try:
-            resp = requests.post(
+            resp = self._session.post(
                 f"{self.base_url}/api/v1/chat",
                 json=payload,
                 headers=self._headers(),
@@ -426,7 +454,7 @@ class OpenAICompatibleProvider(LLMProvider):
             payload["stop"] = stop
 
         try:
-            resp = requests.post(
+            resp = self._session.post(
                 f"{self.base_url}/chat/completions",
                 json=payload,
                 headers=self._headers(),
@@ -462,7 +490,7 @@ class OpenAICompatibleProvider(LLMProvider):
             url = f"{self.base_url}/api/v1/models"
 
         try:
-            resp = requests.get(url, headers=self._headers(), timeout=10)
+            resp = self._session.get(url, headers=self._headers(), timeout=10)
             resp.raise_for_status()
             data = resp.json()
             # LM Studio native uses "models" key; OpenAI uses "data" key
@@ -500,7 +528,7 @@ class OpenAICompatibleProvider(LLMProvider):
             url = f"{self.base_url}/api/v1/models"
 
         try:
-            resp = requests.get(url, headers=self._headers(), timeout=5)
+            resp = self._session.get(url, headers=self._headers(), timeout=5)
             resp.raise_for_status()
             data = resp.json()
             models_list = data.get("data") or data.get("models", [])


### PR DESCRIPTION
## What this fixes
Closes #348

## Root Cause
Both `OllamaProvider` and `OpenAICompatibleProvider` used bare `requests.get/post` calls with no retry logic. A single transient 502/503/504 from a locally-running Ollama or LM Studio instance (e.g. model loading, container restart) would surface immediately as a hard `RuntimeError` to the caller instead of being retried transparently.

## Change Summary
- `backend/providers.py`: added `from requests.adapters import HTTPAdapter` and `from urllib3.util.retry import Retry` (no new pip dependency — both ship with `requests`).  Added module-level `_make_retry_session()` that builds a `requests.Session` with a `Retry` adapter (3 retries, 0.5 s backoff, status forcelist 502/503/504, allowed on GET + POST).  Both provider `__init__` methods now create `self._session` via this helper.  All `requests.get/post` call sites replaced with `self._session.get/post`.

## Merge Disposition
awaits human review
Confidence: MEDIUM
Priority: P2

## Testing
- Existing tests pass: yes
- Covered by: no dedicated retry test — urllib3's Retry adapter is well-tested upstream; integration testing requires a live Ollama/LM Studio instance

---
Auto-fix by daily issue resolver on 2026-06-09

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnLXMkjyk5YRDDxBm9jfDM)_