### PR TITLE
Update daily audit log with gh authentication failure

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -371,3 +371,8 @@ Automated daily code audit results for [BhurkeSiddhesh/Docu-AI-Search](https://g
 
 ## Audit: 2026-05-01
 - Error: gh is not authenticated. GitHub API authentication token is missing or invalid.
+
+## Audit: 2026-06-11
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)


### PR DESCRIPTION
Updated the internal audit log to correctly reflect an authentication failure when checking `gh` availability, adhering to the specified fallback constraints since the environment lacks an active GitHub CLI authentication token.

---
*PR created automatically by Jules for task [16098194610831545936](https://jules.google.com/task/16098194610831545936) started by @BhurkeSiddhesh*