### PR TITLE
Update audit log for auth failure

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -371,3 +371,8 @@ Automated daily code audit results for [BhurkeSiddhesh/Docu-AI-Search](https://g
 
 ## Audit: 2026-05-01
 - Error: gh is not authenticated. GitHub API authentication token is missing or invalid.
+
+## Audit: 2026-06-13
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)


### PR DESCRIPTION
Appended an authentication failure entry to internal_audit_log.md due to missing gh cli.

---
*PR created automatically by Jules for task [2972170738545346659](https://jules.google.com/task/2972170738545346659) started by @BhurkeSiddhesh*