### PR TITLE
Update internal audit log with gh authentication failure

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -371,3 +371,8 @@ Automated daily code audit results for [BhurkeSiddhesh/Docu-AI-Search](https://g
 
 ## Audit: 2026-05-01
 - Error: gh is not authenticated. GitHub API authentication token is missing or invalid.
+
+## Audit: 2026-06-15
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)


### PR DESCRIPTION
Appended an audit failure entry to the `internal_audit_log.md` since the execution environment cannot authenticate with the GitHub CLI (`gh`). Tested `validate_structure.py` to ensure no major structural violations occurred.

---
*PR created automatically by Jules for task [15465323523580717893](https://jules.google.com/task/15465323523580717893) started by @BhurkeSiddhesh*