### PR TITLE
chore: update internal audit log with gh authentication failure

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -371,3 +371,8 @@ Automated daily code audit results for [BhurkeSiddhesh/Docu-AI-Search](https://g
 
 ## Audit: 2026-05-01
 - Error: gh is not authenticated. GitHub API authentication token is missing or invalid.
+
+## Audit: 2026-06-16
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)


### PR DESCRIPTION
Appends the required error entry specifying an authentication failure for the GitHub CLI (`gh`) to `internal_audit_log.md`, fulfilling the automated fallback instruction when `gh` cannot be executed successfully.

---
*PR created automatically by Jules for task [15801016951226024364](https://jules.google.com/task/15801016951226024364) started by @BhurkeSiddhesh*