### PR TITLE
chore: record GitHub CLI auth failure in daily audit log

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -371,3 +371,8 @@ Automated daily code audit results for [BhurkeSiddhesh/Docu-AI-Search](https://g
 
 ## Audit: 2026-05-01
 - Error: gh is not authenticated. GitHub API authentication token is missing or invalid.
+
+## Audit: 2026-06-20
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)


### PR DESCRIPTION
Appends an entry to the audit log explaining that the GitHub CLI (`gh`) authentication failed, avoiding duplicate issue creation attempts and fulfilling the constraints of the daily automated code audit process.

---
*PR created automatically by Jules for task [8001044785494003913](https://jules.google.com/task/8001044785494003913) started by @BhurkeSiddhesh*