### PR TITLE
Update internal_audit_log.md with gh auth failure

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -371,3 +371,8 @@ Automated daily code audit results for [BhurkeSiddhesh/Docu-AI-Search](https://g
 
 ## Audit: 2026-05-01
 - Error: gh is not authenticated. GitHub API authentication token is missing or invalid.
+
+## Audit: 2026-06-24
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)


### PR DESCRIPTION
Appended GitHub CLI auth failure to internal_audit_log.md as per user instructions.

---
*PR created automatically by Jules for task [15900729019030614320](https://jules.google.com/task/15900729019030614320) started by @BhurkeSiddhesh*