### PR TITLE
chore: append gh authentication failure to internal audit log

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -4,6 +4,13 @@ Automated daily code audit results for [BhurkeSiddhesh/Docu-AI-Search](https://g
 
 ---
 
+## Audit: 2026-06-26
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)
+
+---
+
 ## Audit: 2026-05-28
 
 - Issues filed: 6


### PR DESCRIPTION
Updated `internal_audit_log.md` with an entry documenting the `gh` authentication failure since the GitHub CLI is not accessible in this environment. This satisfies the constraint to gracefully handle auth failures during automated issue creation.

---
*PR created automatically by Jules for task [10102525623936705740](https://jules.google.com/task/10102525623936705740) started by @BhurkeSiddhesh*