### PR TITLE
chore: update audit log with authentication failure

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -4,6 +4,12 @@ Automated daily code audit results for [BhurkeSiddhesh/Docu-AI-Search](https://g
 
 ---
 
+## Audit: 2026-07-08
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)
+
+
 ## Audit: 2026-05-28
 
 - Issues filed: 6


### PR DESCRIPTION
Added an entry to the `internal_audit_log.md` noting the lack of GitHub CLI authentication, and safely avoided running the full audit loop as instructed.

---
*PR created automatically by Jules for task [14328463249543194488](https://jules.google.com/task/14328463249543194488) started by @BhurkeSiddhesh*