### PR TITLE
Add GitHub CLI authentication failure to audit log

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -4,6 +4,13 @@ Automated daily code audit results for [BhurkeSiddhesh/Docu-AI-Search](https://g
 
 ---
 
+## Audit: 2026-07-10
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)
+
+---
+
 ## Audit: 2026-05-28
 
 - Issues filed: 6


### PR DESCRIPTION
Appended the GitHub CLI authentication failure message to internal_audit_log.md as requested by the daily automated code audit instructions when `gh` is unavailable.

---
*PR created automatically by Jules for task [11516509160398743466](https://jules.google.com/task/11516509160398743466) started by @BhurkeSiddhesh*