### PR TITLE
security: bump pip deps with coherent langchain-core pin (replaces #393)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,6 @@ rerank = true
 - **test**: Updated existing validate-path tests to patch `_allowed_index_roots`; added coverage for outside-root rejection (no filesystem call made), `..` traversal escaping the root, home-directory default, and the `DOCU_INDEX_ROOTS` override.
 - **docs**: Documented `DOCU_INDEX_ROOTS` in `.env.example`.
 - **Files**: `backend/api.py`, `backend/tests/test_api.py`, `.env.example`, `AGENTS.md`
->>>>>>> origin/main
 
 ### 2026-07-12 (Final release: branch consolidation, issue fixes, feature pruning, UI polish)
 - **merge**: Consolidated every open work branch into one lineage. `fix-frontend-design` (Vercel UI overhaul + model selector, previously unmerged) is now the base; PR branches #329, #330, #331, #333, #343, #351, #352, #323, both Dependabot bumps, and the test-coverage branch were git-merged on top with conflicts resolved in favour of the newest architecture while porting each PR's surviving intent (embedding-batch retry, stream abort hardening, auth header on raw stream fetch, decoder tail flush, `/api/logs` rate limit, `subprocess` timeouts, hashed cache keys).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,11 @@ rerank = true
 
 > **CRITICAL: Add entry here after EVERY change with date, description, and files.**
 
+### 2026-07-14 (Security: pip dependency bumps — replaces unmergeable Dependabot #393)
+- **security**: Bumped `python-multipart` 0.0.30→0.0.31, `langchain` 1.2.7→1.3.13, `langchain-anthropic` 1.3.1→1.4.8, `pytest` 8.3.4→9.0.3 — clears all four open pip Dependabot alerts. Unlike Dependabot PR #393, `langchain-core` is bumped in lockstep (1.3.3→1.4.9, required by langchain 1.3.13), so the set actually resolves; #393 failed CI on ResolutionImpossible.
+- **verification**: Fresh venv installs cleanly; backend quick suite green on the new versions (336 passed, 2 skipped).
+- **Files**: `requirements.txt`, `AGENTS.md`
+
 ### 2026-07-12 (Final release: branch consolidation, issue fixes, feature pruning, UI polish)
 - **merge**: Consolidated every open work branch into one lineage. `fix-frontend-design` (Vercel UI overhaul + model selector, previously unmerged) is now the base; PR branches #329, #330, #331, #333, #343, #351, #352, #323, both Dependabot bumps, and the test-coverage branch were git-merged on top with conflicts resolved in favour of the newest architecture while porting each PR's surviving intent (embedding-batch retry, stream abort hardening, auth header on raw stream fetch, decoder tail flush, `/api/logs` rate limit, `subprocess` timeouts, hashed cache keys).
 - **fix (issues)**: #344 logger.js relative `/api/logs` (via overhaul) · #345 atomic stat in search sort (no TOCTOU 500s) · #346 full AbortSignal plumbing incl. unmount cleanup and reader cancel · #348 HTTP retry for Ollama/OpenAI-compatible providers and model downloads (`_make_retry_session`).

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # Web Framework
 fastapi==0.111.0
 uvicorn==0.30.6
-python-multipart==0.0.30
+python-multipart==0.0.31
 pydantic==2.13.3
 
 # Vector Search
@@ -14,14 +14,14 @@ langchain-huggingface==1.2.0
 numpy==1.26.4
 
 # LLM Integration
-langchain==1.2.7
+langchain==1.3.13
 langchain-community==0.4.1
 langchain-text-splitters==1.1.2
 langchain-google-genai==4.2.0
-langchain-anthropic==1.3.1
+langchain-anthropic==1.4.8
 langchain-openai==1.1.14
 llama-cpp-python==0.2.90
-langchain-core==1.3.3
+langchain-core==1.4.9
 
 # Document Processing
 pypdf==6.13.3
@@ -41,4 +41,4 @@ python-dotenv==1.2.2
 
 # Document Generation & Testing
 reportlab==4.4.9
-pytest==8.3.4
+pytest==9.0.3


### PR DESCRIPTION
## Summary

Dependabot #393 bumps `langchain` to 1.3.13 while leaving `langchain-core` pinned at 1.3.3 — but langchain 1.3.13 requires `langchain-core>=1.4.9`, so the requirement set is unresolvable and #393 fails CI at `pip install` (ResolutionImpossible).

This PR applies the same four security bumps **plus** `langchain-core` in lockstep:

| Package | From | To |
|---|---|---|
| python-multipart | 0.0.30 | 0.0.31 |
| langchain | 1.2.7 | 1.3.13 |
| langchain-anthropic | 1.3.1 | 1.4.8 |
| pytest | 8.3.4 | 9.0.3 |
| langchain-core | 1.3.3 | **1.4.9** |

Clears all four open **pip** Dependabot alerts (medium ×3, low ×1). Once merged, #393 can be closed (Dependabot should mark it obsolete).

## Verification
- Fresh venv: `pip install -r requirements.txt` resolves and installs cleanly (Python 3.10).
- Backend quick suite on the new versions: **336 passed, 2 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)