### PR TITLE
security: model-path allow-list + generic download errors (final 3 CodeQL alerts)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,8 @@ GROK_API_KEY=
 # may inspect, beyond the home directory and already-configured index folders.
 # Example (Linux/macOS): DOCU_INDEX_ROOTS=/mnt/docs:/srv/shared
 DOCU_INDEX_ROOTS=
+
+# Optional: extra directory roots (os.pathsep-separated) a configured GGUF
+# model path may live under, beyond models/ and the home directory.
+# Example (Linux/macOS): DOCU_MODEL_ROOTS=/srv/gguf
+DOCU_MODEL_ROOTS=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
         python-version: '3.10'
 
     - name: Install security tools
-      run: pip install bandit pip-audit
+      # setuptools pinned >=83.0.0: the runner toolcache ships 79.0.1,
+      # which pip-audit flags (PYSEC-2026-3447) and fails the job.
+      run: pip install --upgrade "setuptools>=83.0.0" bandit pip-audit
 
     - name: Run Bandit (static security analysis)
       run: bandit -r backend -f json -o bandit-report.json -ll

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ rerank = true
 - **security**: Model-download failures now surface a generic error in `/api/models/download/status`; exception details go to the server log only (`py/stack-trace-exposure`, medium). — `backend/model_manager.py`
 - **test**: `TestResolveModelPath` (7 tests: models/ and home allowed, outside-root and deep-traversal rejected, empty/None rejected, env override, `get_local_llm` rejection). Fixed stale gemini default assertion (`gemini-2.0-flash`→`gemini-flash-latest`) in `test_llm_integration.py` — latent failure not caught by CI because the quick suite doesn't include this file.
 - **docs**: `DOCU_MODEL_ROOTS` documented in `.env.example`.
+- **ci**: security-scan job upgrades `setuptools>=83.0.0` before pip-audit — the runner toolcache ships 79.0.1, newly flagged by PYSEC-2026-3447, which failed the job on every PR.
 - **Files**: `backend/llm_integration.py`, `backend/model_manager.py`, `backend/tests/test_llm_integration.py`, `.env.example`, `AGENTS.md`
 
 ### 2026-07-14 (Security: pip dependency bumps — replaces unmergeable Dependabot #393)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,13 @@ rerank = true
 
 > **CRITICAL: Add entry here after EVERY change with date, description, and files.**
 
+### 2026-07-14 (Security: model-path allow-list + generic download errors — resolves final 3 CodeQL alerts)
+- **security**: `get_local_llm` and the `provider='local'` client factory no longer touch the filesystem with a raw configured model path (`py/path-injection` ×2, high). `_resolve_model_path` normalizes with pure string ops and requires the result under an allowed root — `models/`, the home directory, or the new `DOCU_MODEL_ROOTS` env var (os.pathsep-separated).
+- **security**: Model-download failures now surface a generic error in `/api/models/download/status`; exception details go to the server log only (`py/stack-trace-exposure`, medium). — `backend/model_manager.py`
+- **test**: `TestResolveModelPath` (7 tests: models/ and home allowed, outside-root and deep-traversal rejected, empty/None rejected, env override, `get_local_llm` rejection). Fixed stale gemini default assertion (`gemini-2.0-flash`→`gemini-flash-latest`) in `test_llm_integration.py` — latent failure not caught by CI because the quick suite doesn't include this file.
+- **docs**: `DOCU_MODEL_ROOTS` documented in `.env.example`.
+- **Files**: `backend/llm_integration.py`, `backend/model_manager.py`, `backend/tests/test_llm_integration.py`, `.env.example`, `AGENTS.md`
+
 ### 2026-07-14 (Security: pip dependency bumps — replaces unmergeable Dependabot #393)
 - **security**: Bumped `python-multipart` 0.0.30→0.0.31, `langchain` 1.2.7→1.3.13, `langchain-anthropic` 1.3.1→1.4.8, `pytest` 8.3.4→9.0.3 — clears all four open pip Dependabot alerts. Unlike Dependabot PR #393, `langchain-core` is bumped in lockstep (1.3.3→1.4.9, required by langchain 1.3.13), so the set actually resolves; #393 failed CI on ResolutionImpossible.
 - **verification**: Fresh venv installs cleanly; backend quick suite green on the new versions (336 passed, 2 skipped).

--- a/backend/llm_integration.py
+++ b/backend/llm_integration.py
@@ -342,15 +342,62 @@ def get_embedding_client(provider_type: str, model_name: str = None, api_key: st
     )
 
 
+def _allowed_model_roots() -> tuple:
+    """Directory roots a configured GGUF model path may live under.
+
+    The models/ download directory and the user's home directory by default;
+    extra roots can be granted via the DOCU_MODEL_ROOTS environment variable
+    (os.pathsep-separated). Roots are canonicalized and returned with a
+    trailing separator so a prefix match cannot leak into sibling directories.
+    """
+    from backend.model_manager import MODELS_DIR
+    candidates = [MODELS_DIR, os.path.expanduser("~")]
+    env_roots = os.environ.get('DOCU_MODEL_ROOTS', '')
+    candidates += [p.strip() for p in env_roots.split(os.pathsep) if p.strip()]
+    roots = []
+    for candidate in candidates:
+        try:
+            real = os.path.realpath(candidate)
+        except (ValueError, TypeError, OSError):
+            continue
+        if not real.endswith(os.sep):
+            real += os.sep
+        roots.append(real)
+    return tuple(roots)
+
+
+def _resolve_model_path(model_path: str) -> Optional[str]:
+    """Normalize a configured model path and require it under an allowed root.
+
+    Pure string normalization — no filesystem call sees the raw value. Returns
+    the normalized path, or None if the path is empty or escapes the allowed
+    roots (models/, home, DOCU_MODEL_ROOTS).
+    """
+    if not model_path:
+        return None
+    try:
+        normalized = os.path.abspath(os.path.normpath(model_path))
+    except (ValueError, TypeError):
+        return None
+    if normalized.startswith(_allowed_model_roots()):
+        return normalized
+    logger.warning(
+        "Configured model path is outside the allowed roots "
+        "(models/, home directory, DOCU_MODEL_ROOTS): %s", str(model_path).replace('\n', '\\n')
+    )
+    return None
+
+
 def get_local_llm(model_path: str, tensor_split: List[float] = None) -> Any:
     """
     Load and cache the GGUF model directly with LlamaCpp.
 
-    This function implements "blazing fast" inference settings for local models, 
+    This function implements "blazing fast" inference settings for local models,
     including GPU offloading and Flash Attention.
 
     Args:
         model_path (str): Absolute or relative path to the GGUF model file.
+            Must resolve under models/, the home directory, or DOCU_MODEL_ROOTS.
         tensor_split (List[float], optional): Distribution of model across multiple GPUs.
 
     Returns:
@@ -360,10 +407,11 @@ def get_local_llm(model_path: str, tensor_split: List[float] = None) -> Any:
         logger.warning("llama_cpp not installed")
         return None
 
-        
-    if not model_path or not os.path.exists(model_path):
+    resolved = _resolve_model_path(model_path)
+    if not resolved or not os.path.exists(resolved):
         logger.info(f"Model not found at {model_path}")
         return None
+    model_path = resolved
 
     if model_path in _llm_cache:
         return _llm_cache[model_path]
@@ -503,7 +551,8 @@ def get_llm_client(provider: str, api_key: str = None, model_path: str = None, b
         elif provider == 'local':
             # For local, we don't return a LangChain object because we are using llama-cpp-python directly
             # for better control over the 'create_completion' call in generate_ai_answer currently.
-            if not model_path or not os.path.exists(model_path):
+            checked_path = _resolve_model_path(model_path)
+            if not checked_path or not os.path.exists(checked_path):
                 model_path = _discover_local_gguf()
                 if not model_path:
                     logger.warning("Local model path missing and no GGUF found in models/")

--- a/backend/model_manager.py
+++ b/backend/model_manager.py
@@ -603,13 +603,15 @@ def download_file(url, filename, model_id, total_bytes=0):
             }
 
     except Exception as e:
-        _logger.error("Download failed: %s", e)
+        _logger.error("Download failed: %s", e, exc_info=True)
         with _download_lock:
             download_status = {
                 "downloading": False,
                 "model_id": model_id,
                 "progress": 0,
-                "error": str(e),
+                # Generic message only — exception details (which can carry
+                # stack/internal info) stay in the server log.
+                "error": "Download failed. Check the server log for details.",
                 "bytes_downloaded": 0,
                 "total_bytes": 0
             }

--- a/backend/tests/test_llm_integration.py
+++ b/backend/tests/test_llm_integration.py
@@ -23,7 +23,7 @@ class TestLLMIntegrationV2(unittest.TestCase):
         """Test getting Gemini client."""
         client = get_llm_client('gemini', api_key='AIza-test')
         self.assertIsNotNone(client)
-        mock_gemini.assert_called_with(google_api_key='AIza-test', model='gemini-2.0-flash', temperature=0.3)
+        mock_gemini.assert_called_with(google_api_key='AIza-test', model='gemini-flash-latest', temperature=0.3)
 
     @patch('backend.llm_integration.ChatAnthropic')
     def test_get_llm_client_anthropic(self, mock_anthropic):
@@ -130,6 +130,50 @@ class TestInvokeWithRetry(unittest.TestCase):
         # backoff: 2**0=1, 2**1=2
         sleep_calls = [c[0][0] for c in mock_sleep.call_args_list]
         self.assertEqual(sleep_calls, [1, 2])
+
+
+class TestResolveModelPath(unittest.TestCase):
+    """Model paths must resolve under an allowed root (models/, home, DOCU_MODEL_ROOTS)."""
+
+    def test_path_under_models_dir_allowed(self):
+        from backend.llm_integration import _resolve_model_path
+        from backend.model_manager import MODELS_DIR
+        path = os.path.join(MODELS_DIR, "test.gguf")
+        self.assertEqual(_resolve_model_path(path), os.path.abspath(path))
+
+    def test_path_under_home_allowed(self):
+        from backend.llm_integration import _resolve_model_path
+        path = os.path.join(os.path.expanduser("~"), "my-models", "test.gguf")
+        self.assertEqual(_resolve_model_path(path), os.path.abspath(path))
+
+    def test_path_outside_roots_rejected(self):
+        from backend.llm_integration import _resolve_model_path
+        self.assertIsNone(_resolve_model_path("/etc/passwd"))
+
+    def test_traversal_escaping_root_rejected(self):
+        from backend.llm_integration import _resolve_model_path
+        from backend.model_manager import MODELS_DIR
+        sneaky = os.path.join(MODELS_DIR, *([".."] * 12), "etc", "passwd")
+        self.assertIsNone(_resolve_model_path(sneaky))
+
+    def test_empty_path_rejected(self):
+        from backend.llm_integration import _resolve_model_path
+        self.assertIsNone(_resolve_model_path(""))
+        self.assertIsNone(_resolve_model_path(None))
+
+    def test_env_override_grants_extra_root(self):
+        from backend.llm_integration import _resolve_model_path
+        with patch.dict(os.environ, {"DOCU_MODEL_ROOTS": "/srv/gguf"}):
+            self.assertEqual(
+                _resolve_model_path("/srv/gguf/model.gguf"), "/srv/gguf/model.gguf"
+            )
+
+    def test_get_local_llm_rejects_out_of_root_path(self):
+        import backend.llm_integration as llm_mod
+        if llm_mod.Llama is None:
+            self.skipTest("llama_cpp not installed")
+        with patch("os.path.exists", return_value=True):
+            self.assertIsNone(llm_mod.get_local_llm("/etc/passwd"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Resolves the last three open code-scanning alerts on main (predating #391, so they never gated a PR):

- **py/path-injection (high) ×2** — `backend/llm_integration.py:364,506`: the configured GGUF model path flowed from `/api/config` into `os.path.exists` / `Llama` unchecked. `_resolve_model_path` now normalizes with pure string ops and requires the result under an allowed root: `models/`, the home directory, or the new `DOCU_MODEL_ROOTS` env var (`os.pathsep`-separated). Same sanitizer pattern that closed the validate-path alerts in #397.
- **py/stack-trace-exposure (medium)** — `backend/api.py:663`: download failures returned `str(e)` to the client via `/api/models/download/status`. Now a generic message; full details logged server-side with `exc_info=True`.

Also fixes a stale test assertion (gemini default is `gemini-flash-latest`; test expected `gemini-2.0-flash`) — latent because the CI quick suite doesn't include `test_llm_integration.py`.

## Verification
- New `TestResolveModelPath` (7 cases: models/ and home allowed, outside-root and deep-traversal rejected, empty/None rejected, env override, `get_local_llm` rejection with a spoofed `os.path.exists`).
- Backend quick suite: **340 passed, 2 skipped, 0 failed**; `test_llm_integration`, `test_llm_integration_full`, `test_model_manager` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)