### PR TITLE
chore: Update daily audit log for gh auth failure

### DIFF
--- a/internal_audit_log.md
+++ b/internal_audit_log.md
@@ -4,6 +4,13 @@ Automated daily code audit results for [BhurkeSiddhesh/Docu-AI-Search](https://g
 
 ---
 
+## Audit: 2026-07-19
+- Issues filed: 0
+- Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience
+- Status: Authentication failure for GitHub CLI (gh)
+
+---
+
 ## Audit: 2026-07-14
 - Issues filed: 0
 - Categories: 0 Critical Bug, 0 Logic Enhancement, 0 Developer Experience


### PR DESCRIPTION
Added an entry to internal_audit_log.md for an authentication failure of the GitHub CLI (gh) since the environment lacks auth to run `gh issue list` and file issues. The required format was strictly followed.

---
*PR created automatically by Jules for task [2342270871726003428](https://jules.google.com/task/2342270871726003428) started by @BhurkeSiddhesh*